### PR TITLE
Reuse of HTTP connections between SCIM operations

### DIFF
--- a/src/simplescim_scim_send.hpp
+++ b/src/simplescim_scim_send.hpp
@@ -25,10 +25,11 @@
 
 #include <string>
 #include <optional>
+#include <curl/curl.h>
 
 class scim_sender {
 public:
-    static scim_sender instance() {
+    static scim_sender& instance() {
         static scim_sender sender;
         return sender;
     }
@@ -108,6 +109,9 @@ public:
      * error message.
      */
     long send_delete(const std::string &url);
+
+private:
+    CURL *curl;
 };
 
 #endif


### PR DESCRIPTION
Only one CURL easy session per config file (instead of one per SCIM operation)

Fixes #16
