### PR TITLE
Fixes #26 (UUID handling)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,5 +3,6 @@
 * Unreleased
     - Bugfixes:
         - Expansion of ${value} in LDAP relations (#23)
+	- Better handling of UUIDs (#26)
     - New features:
 	- Deletes are done in reverse scim-type-send-order order (#4)

--- a/master_config/master.conf
+++ b/master_config/master.conf
@@ -9,7 +9,19 @@ ldap-base      = ou=Users,o=Organisation # -b in ldapsearch
 ldap-scope     = SUBTREE # BASE, ONELEVEL, SUBTREE or CHILDREN # -s in ldapsearch
 ldap-attrsonly = FALSE
 
-ldap-UUID      = GUID      # attribute name of the unique identifier
+# Attribute name of the unique identifier if the LDAP server stores
+# UUIDs in binary form (16 octets). 
+#
+# Typical settings:
+#
+# LDAP server        Attribute name
+# ---------------------------------
+# eDirectory         GUID
+# Active Directory   objectGUID
+#
+# If your LDAP stores UUIDs in text form (like OpenLDAP), skip this
+# parameter or leave it empty.
+ldap-UUID      = GUID
 
 # scim-auth-WEAK = TRUE
 # scim-media-type = application/json

--- a/src/ldap_wrapper.cpp
+++ b/src/ldap_wrapper.cpp
@@ -135,13 +135,7 @@ struct ldap_wrapper::Impl {
     ldap_attrs = config.get("ldap-attrs", true);
     ldap_UUID = config.get("ldap-UUID", true);
     ldap_attrsonly = config.get("ldap-attrsonly");
-    if (ldap_UUID.empty()) {
-      ldap_UUID = "GUID";
-      std::cout << "ldap variable ldap_UUID is missing. GUID assumed. If your catalogue \n"
-	"is using a different attibute name for unique id enter this in the configuration. \n"
-	"for example, openldap uses entityUUID. \n"
-	"If your unique id is indeed GUID, enter this variable anyway to silence this message." << std::endl;
-    }
+
     if (!ldap_attrs.empty())
       std::cout
 	<< "ldap_attrs are generated from variables used in the scim templates. It is safe to leave this empty"

--- a/src/simplescim_ldap.cpp
+++ b/src/simplescim_ldap.cpp
@@ -90,7 +90,7 @@ std::shared_ptr<object_list> get_object_list_by_type(const std::string &type, co
  * This needs to be maintained through new versions of EGIL.
  */
 std::string create_relational_id(const string_pair &index_fields) {
-  return uuid_util::instance().generate(toUpper(index_fields.first), toUpper(index_fields.second));
+  return uuid_util::instance().generate(index_fields.first, index_fields.second);
 }
 
 /**

--- a/src/utility/utils.cpp
+++ b/src/utility/utils.cpp
@@ -187,15 +187,9 @@ std::string toUpper(const std::string &s) {
     return out;
 }
 
-std::string &toUpper(std::string &s) {
-    std::transform(s.begin(), s.end(), s.begin(), ::toupper);
-    return s;
-}
-
 std::string uuid_util::generate() {
     boost::uuids::uuid uuid = generator();
-    std::string id = boost::uuids::to_string(uuid);
-    return toUpper(id);
+    return boost::uuids::to_string(uuid);
 }
 
 std::string uuid_util::generate(const std::string &a, const std::string &b) {
@@ -212,13 +206,11 @@ std::string uuid_util::generate(const std::string &a, const std::string &b) {
 #endif
 
     boost::uuids::uuid uuid = name_generator(a + b);
-    std::string id = boost::uuids::to_string(uuid);
-    return toUpper(id);
+    return boost::uuids::to_string(uuid);
 }
 
 std::string uuid_util::un_parse_uuid(char *val) {
     boost::uuids::uuid uuid{};
     ::memcpy(&uuid, val, 16);
-    auto st = boost::lexical_cast<std::string>(uuid);
-    return toUpper(st);
+    return boost::lexical_cast<std::string>(uuid);
 }

--- a/src/utility/utils.hpp
+++ b/src/utility/utils.hpp
@@ -40,8 +40,6 @@ std::pair<std::string, std::string> string_to_pair(const std::string &s);
 
 std::string pair_to_string(const std::pair<std::string, std::string> &pair);
 
-std::string &toUpper(std::string &s);
-
 std::string toUpper(const std::string &s);
 
 void print_error();


### PR DESCRIPTION
UUIDs are no longer converted to upper case (they shouldn't be according to spec).

Also allow an empty setting for ldap-UUID, which simply means we don't do any conversion from binary UUID to text (useful for OpenLDAP which stores UUIDs as text).

Fixes #26 