### PR TITLE
The rebuild-cache function now looks at "id" instead of "externalId"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
   - LDAP-parameters are no longer necessary when using method = "object" (#51)
   - Fixed a bug that could lead to segmentation fault when a delete failed (#62)
   - Activity and Employment objects are now included in load log file (#47)
+  - The rebuild-cache function now looks at "id" instead of "externalId" (#45)
 
 ### v2.1.0 (2019-07-02)
 #### Bugfixes

--- a/src/scim.cpp
+++ b/src/scim.cpp
@@ -476,7 +476,7 @@ std::vector<ScimActions::scim_object_ref> ScimActions::get_all_objects_from_scim
         scim_sender::instance().query(url, resources);
 
         for (const auto& resource : resources) {
-            auto uuid = resource.get<std::string>("externalId");
+            auto uuid = resource.get<std::string>("id");
             results.push_back(scim_object_ref(uuid, endpoint));
         }
     }


### PR DESCRIPTION
Fixes #45