### PR TITLE
Include the stdexcept header

### DIFF
--- a/src/post_processing.cpp
+++ b/src/post_processing.cpp
@@ -17,6 +17,8 @@
  *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+#include <stdexcept>
+
 #include "post_processing.hpp"
 
 #include "plugin_config.hpp"

--- a/src/sql.cpp
+++ b/src/sql.cpp
@@ -17,6 +17,8 @@
  *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+#include <stdexcept>
+
 #include "sql.hpp"
 #include "plugin_config.hpp"
 


### PR DESCRIPTION
post_processing.cpp and sql.cpp uses `std::runtime_error` which is
defined in the stdexcept header. Without it, the compilation were
failing with `error: ‘runtime_error’ is not a member of ‘std’`.