### PR TITLE
Concatenate the scenario paths with the test root

### DIFF
--- a/test/test_server_go/EGILTestServer/main.go
+++ b/test/test_server_go/EGILTestServer/main.go
@@ -163,7 +163,7 @@ func runTest(testName, testPath string,
 
 		// Apply scenario
 		for _, scen := range step.Scenario {
-			cmd := exec.Command(path.Join(testRoot, "scripts", "apply_scenario"), scen)
+			cmd := exec.Command(path.Join(testRoot, "scripts", "apply_scenario"), path.Join(testRoot, scen))
 			err = cmd.Run()
 
 			if err != nil {


### PR DESCRIPTION
The test suite was only running correctly when started inside the test
directory before. Now it is possible to run it from anywhere.