### PR TITLE
Add Nix flake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ cmake-build-debug/*
 test/test_server_go/EGILTestServer/EGILTestServer
 
 *.pem
+
+# nix build
+/result*

--- a/doc/DEBUG.md
+++ b/doc/DEBUG.md
@@ -16,6 +16,12 @@ with
 cmake -DCMAKE_BUILD_TYPE=Debug ..
 ```
 
+## Building with Nix
+```shell
+cd <project-root>
+nix build '.#scim-client.debug'
+```
+
 ## Post-mortem investigation of a crash
 
 To do a post-mortem investigation of a crash, we need the following:

--- a/doc/INSTALL.md
+++ b/doc/INSTALL.md
@@ -68,6 +68,10 @@ Run EgilSCIM with:
 
 # System specific instructions
 
+## Nix package manager
+    cd <project-root>
+    nix build
+
 ## Ubuntu Server 18.04 LTS
     sudo apt install cmake libldap2-dev libcurl4-openssl-dev libboost-all-dev
     cd EgilSCIM/build

--- a/doc/NIX.md
+++ b/doc/NIX.md
@@ -1,0 +1,63 @@
+# Nix
+At the root of the repository there is a [flake.nix](../flake.nix) file that
+defines nix expressions to build various programs/tools/scripts that is used
+inside the repository, as well as a VM test and a development shell. All of
+these can be used with the [Nix package manager](https://nixos.org/) without
+needing any other dependency.
+
+## Supported systems
+The flake is usable for systems included in the `defaultSystems`[^1] defined by
+the "flake-utils" library. Which includes at the time of writing:
+
+### Linux
+- aarch64
+- i686
+- x86_64
+
+### Darwin
+- aarch64
+- x86_64
+
+[^1]: https://github.com/numtide/flake-utils/blob/master/default.nix#L3
+
+## Packages
+- `plugins/echo`: An example plugin for EgilSCIM.
+- `scim-client`: The main application of the repository.
+- `scim-client.debug`: The same as `scim-client` but built with debug flags
+  enabled.
+- `test/server`: The test server that can bu used with the test suite. See
+  [the test server README](../test/test_server_go/README.md) for more
+  information.
+- `test/suite`: The system test suite for EgilSCIM.
+- `tools`: An umbrella package that contains the other tools. See [the Egil
+  tools README](../tools/README.md) for more information.
+- `tools/fetch_metadata`
+- `tools/list_metadata`
+- `tools/public_key_pin`
+
+## Hydra VM test
+A VM test for the system test suite is defined to be run by an Hydra instance
+but it could also be run manually with:
+```shell
+nix build '.#hydraJobs.vmTest.egil-test-suite.x86_64-linux'
+```
+Note that the VM test is only for "x86_64-linux" systems; partly because NixOS
+test driver only works for Linux OS and partly because the Docker image used by
+the test suite is only available for the "x86_64" architecture.
+
+## devShell
+There is a `devShell` defined which can be used with `nix develop` to start an
+development shell with the build environment of `scim-client.debug`. On top of
+the dependencies of `scim-client.debug`, `gdb` and `egil/test/suite` is also
+usable within the shell.
+
+So you can run the test suite by just typing `run_test_suite` in the shell
+without needing to install `docker` cli or `openssl`. One thing that is required
+is the docker daemon, which is not possible to install with a nix shell as far
+as I know.
+
+On the other hand, you can start debugging the EgilSCIM with just typing `gdb
+EgilSCIMClient`, which should start the gdb with the external debug
+symbols of the dependencies already loaded if they exist. The source code
+directory will also be correctly found by the gdb, regardless of the location
+that it is started from.

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,79 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1638122382,
+        "narHash": "sha256-sQzZzAbvKEqN9s0bzWuYmRaA03v40gaJ4+iL1LXjaeI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "74f7e4319258e287b0f9cb95426c9853b282730b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nix-filter": {
+      "locked": {
+        "lastModified": 1641407557,
+        "narHash": "sha256-LRMVr6+dbmNv3I/8TepDoNsv0AaNR4/1R1qv0Okhtc8=",
+        "owner": "numtide",
+        "repo": "nix-filter",
+        "rev": "bd03eb5242e707bc270f7a7e4f835b55713247ac",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "nix-filter",
+        "type": "github"
+      }
+    },
+    "nix-utils": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1642379196,
+        "narHash": "sha256-fSPpAETgZ21Ka8FOZQFZLuZwN0XDtdAHPXYXbrqRtXw=",
+        "owner": "ilkecan",
+        "repo": "nix-utils",
+        "rev": "429393fcc3ee84876955305b8f641ed45514c22e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ilkecan",
+        "repo": "nix-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1641870998,
+        "narHash": "sha256-6HkxR2WZsm37VoQS7jgp6Omd71iw6t1kP8bDbaqCDuI=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "386234e2a61e1e8acf94dfa3a3d3ca19a6776efb",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixos-21.11",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nix-filter": "nix-filter",
+        "nix-utils": "nix-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,100 @@
+{
+  description = "The EGIL SCIM client";
+
+  inputs = {
+    nixpkgs.url = "nixpkgs/nixos-21.11";
+    flake-utils.url = "github:numtide/flake-utils";
+    nix-filter.url = "github:numtide/nix-filter";
+
+    nix-utils = {
+      url = "github:ilkecan/nix-utils";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs = { self, nixpkgs, ... }@inputs:
+    let
+      inherit (builtins) elem;
+      inherit (nixpkgs.lib) filterAttrs;
+
+      inherit (inputs.flake-utils.lib)
+        defaultSystems
+        eachSystem
+        flattenTree
+      ;
+
+      inherit (inputs.nix-utils.lib)
+        createDebugSymbolsSearchPath
+        getCmakeVersion
+        getUnstableVersion
+      ;
+
+      supportedSystems = defaultSystems;
+      version =
+        if self.sourceInfo ? rev
+        then getCmakeVersion ./CMakeLists.txt
+        else getUnstableVersion self.lastModifiedDate;
+
+      meta = {
+        homepage = "https://www.skolfederation.se/egil-scimclient-esc/";
+        downloadPage = "https://github.com/Sambruk/EgilSCIM/releases";
+        changelog = "https://raw.githubusercontent.com/Sambruk/EgilSCIM/master/CHANGELOG.md";
+        maintainers = with nixpkgs.lib.maintainers; [ ilkecan ];
+        platforms = supportedSystems;
+      };
+
+      privateOverlay = final: prev:
+        let
+          inherit (prev) callPackage;
+        in
+        {
+          nix-filter = inputs.nix-filter.lib;
+          egil = prev.egil // {
+            internal = {
+              inherit version meta;
+            };
+          };
+        };
+    in
+    {
+      overlay = import ./nix/overlay.nix {
+        inherit privateOverlay;
+      };
+    } // eachSystem supportedSystems (system:
+      let
+        pkgs = import nixpkgs {
+          inherit system;
+          overlays = [
+            inputs.nix-utils.overlay
+            self.overlay
+          ];
+        };
+
+        inherit (pkgs) egil callPackage;
+        inherit (pkgs.stdenv) isLinux;
+
+        isSupportedOnCurrentSystem = drv:
+          elem system drv.meta.platforms;
+      in
+      rec {
+        checks = packages;
+
+        packages = filterAttrs (_: isSupportedOnCurrentSystem) (flattenTree egil);
+        defaultPackage = packages.scim-client;
+
+        hydraJobs = {
+          build = checks;
+
+          ${ if isLinux then "vmTest" else null } =
+            let
+              drv = egil.test.suite;
+            in
+            {
+              ${ if isSupportedOnCurrentSystem drv then drv.pname else null } = drv.vmTest;
+            };
+        };
+
+        devShell = callPackage ./nix/shell.nix { inherit isSupportedOnCurrentSystem; };
+      }
+    );
+}

--- a/nix/compat/default.nix
+++ b/nix/compat/default.nix
@@ -1,0 +1,3 @@
+(import (fetchTarball https://github.com/edolstra/flake-compat/archive/master.tar.gz) {
+  src = builtins.fetchGit ./..;
+}).defaultNix

--- a/nix/compat/shell.nix
+++ b/nix/compat/shell.nix
@@ -1,0 +1,3 @@
+(import (fetchTarball https://github.com/edolstra/flake-compat/archive/master.tar.gz) {
+  src = builtins.fetchGit ./..;
+}).shellNix

--- a/nix/egil/plugins/echo.nix
+++ b/nix/egil/plugins/echo.nix
@@ -1,0 +1,42 @@
+{ lib
+, egil
+, stdenv
+}:
+
+let
+  inherit (egil.internal) meta version;
+in
+stdenv.mkDerivation {
+  pname = "egil-plugins-echo";
+  inherit version;
+
+  src = ./../../../plugins/pp/echo;
+
+  outputs = [ "lib" "out" ];
+  propagatedBuildOutputs = [ ];
+
+  strictDeps = true;
+
+  buildInputs = [
+    egil.scim-client.dev
+  ];
+
+  dontPatch = true;
+  dontConfigure = true;
+
+  installPhase = ''
+    mkdir -p $lib/lib/
+    cp libecho.so $lib/lib/
+
+    mkdir $out
+  '';
+
+  meta = meta // {
+    description = "An example plugin for EgilSCIM";
+    longDescription = ''
+      An example plugin which simply copies the input text without making any
+      real post processing changes.
+    '';
+    license = lib.licenses.agpl3Plus;
+  };
+}

--- a/nix/egil/scim-client.nix
+++ b/nix/egil/scim-client.nix
@@ -1,0 +1,92 @@
+{ lib
+, boost
+, cmake
+, curl
+, egil
+, nix-filter
+, openldap
+, stdenv
+, doCheck ? true
+, isDebugBuild ? false
+}:
+
+let
+  inherit (lib) optionalString;
+  inherit (nix-filter) inDirectory;
+  inherit (egil.internal) version meta;
+
+  pname = "egil-scim-client";
+  mainProgram = "EgilSCIMClient";
+in
+stdenv.mkDerivation {
+  inherit pname;
+  version = "${version}${optionalString isDebugBuild "-debug"}";
+
+  src = nix-filter {
+    root = ./../..;
+    include = [
+      "CMakeLists.txt"
+      (inDirectory "src")
+    ];
+    name = pname;
+  };
+
+  outputs = [ "bin" "dev" "out" ];
+  propagatedBuildOutputs = [ ];
+
+  strictDeps = true;
+
+  buildInputs = [
+    boost.dev
+    curl.dev # libcurl
+    openldap.dev # libldap
+  ];
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  dontPatch = true;
+
+  cmakeFlags = [
+    (optionalString isDebugBuild "-DCMAKE_BUILD_TYPE=Debug")
+  ];
+
+  inherit doCheck;
+  checkPhase = ''
+    ./tests
+  '';
+
+  installPhase = ''
+    mkdir -p $bin/bin/
+    cp ${mainProgram} $bin/bin/${mainProgram}
+
+    mkdir -p $dev/include/
+    cp ../src/pp_interface.h $dev/include/
+
+    mkdir $out
+  '';
+
+  dontStrip = isDebugBuild;
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    $bin/bin/${mainProgram} --version
+  '';
+
+  passthru = {
+    debug = egil.scim-client.override { isDebugBuild = true; };
+  };
+
+  meta = meta // {
+    description = "The EGIL SCIM client";
+    longDescription = ''
+      The EGIL SCIM client implements the EGIL profile of the SS 12000
+      standard. It reads information about students, groups etc. from LDAP and
+      sends updates to a SCIM server.
+    '';
+
+    license = lib.licenses.agpl3Plus;
+    inherit mainProgram;
+  };
+}

--- a/nix/egil/test/server.nix
+++ b/nix/egil/test/server.nix
@@ -1,0 +1,31 @@
+{ lib
+, buildGoModule
+, egil
+}:
+
+let
+  inherit (egil.internal) version meta;
+  mainProgram = "EGILTestServer";
+in
+buildGoModule {
+  pname = "egil-test-server";
+  inherit version;
+  src = ./../../../test/test_server_go/${mainProgram};
+
+  vendorSha256 = "sha256-pQpattmS9VmO3ZIQUFn66az8GSmB4IvYhTTCFn6SUmo=";
+
+  dontPatch = true;
+
+  meta = meta // {
+    description = "Test server for EgilSCIM";
+    longDescription = ''
+      A simple server using openssl with the purpose of testing the current set
+      up of EgilSCIM. It is not a complete SCIM server, it simply receives and
+      logs the requests done by the client and returns successful status codes
+      back so the client thinks everything is accepted.
+    '';
+
+    license = lib.licenses.agpl3Plus;
+    inherit mainProgram;
+  };
+}

--- a/nix/egil/test/suite.nix
+++ b/nix/egil/test/suite.nix
@@ -1,0 +1,91 @@
+{ lib
+, bash
+, docker
+, egil
+, callPackage
+, makeWrapper
+, nix-filter
+, openssl
+, stdenvNoCC
+}:
+
+let
+  inherit (lib) makeSearchPath;
+  inherit (nix-filter) inDirectory;
+  inherit (egil.internal) meta version;
+
+  pname = "egil-test-suite";
+  mainProgram = "run_test_suite";
+
+  buildInputs = [
+    bash.out
+    docker.out
+    egil.scim-client.bin
+    egil.test.server
+    openssl.bin
+  ];
+in
+stdenvNoCC.mkDerivation {
+  inherit pname version;
+  src = nix-filter {
+    root = ./../../../test;
+    include = [
+      (inDirectory "configs")
+      (inDirectory "scenarios")
+      (inDirectory "scripts")
+      (inDirectory "tests")
+    ];
+    name = pname;
+  };
+
+  strictDeps = true;
+
+  inherit buildInputs;
+  nativeBuildInputs = [
+    makeWrapper
+  ];
+
+  patchPhase = ''
+    substituteInPlace ./scripts/${mainProgram} \
+      --replace "\''${testroot}/test_server_go/EGILTestServer/" "" \
+      --replace "\''${testroot}/../build/" ""
+  '';
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    cp -r . $out
+
+    mkdir $out/bin/
+    ln -s $out/scripts/${mainProgram} $out/bin/${mainProgram}
+  '';
+
+  postFixup = ''
+    for file in $out/scripts/*; do
+      [ -f "$file" ] && [ -x "$file" ] || continue
+      wrapProgram "$file" --prefix PATH : "${makeSearchPath "bin" buildInputs}"
+    done
+  '';
+
+  passthru = {
+    vmTest = callPackage ./vm-test.nix { };
+  };
+
+  meta = meta // {
+    description = "The EGIL test suite";
+    longDescription = ''
+      The system test suite includes an LDAP server and a way to automatically
+      populate it with example students, groups, teachers, school units etc.
+      There's also a simple system for running scenarios ("Student X is
+      deleted"). This might be of interest also for those that want to test
+      their server implementations.
+    '';
+
+    license = null;
+    platforms = [
+      "x86_64-linux"
+    ];
+    inherit mainProgram;
+  };
+}

--- a/nix/egil/test/vm-test.nix
+++ b/nix/egil/test/vm-test.nix
@@ -1,0 +1,47 @@
+{ dockerTools
+, writeShellScript
+, egil
+, nixosTest,
+}:
+
+let
+  inherit (dockerTools) pullImage;
+
+  dockerImages = [
+    (pullImage {
+      imageName = "osixia/openldap";
+      imageDigest = "sha256:d212a12aa728ccb4baf06fcc83dc77392d90018d13c9b40717cf455e09aeeef3";
+      sha256 = "sha256-91CSC1kVGgMB7ZRoiuLjn5YpBZIgcZDcmJzwQNJYg/U=";
+      os = "linux";
+      arch = "amd64";
+      finalImageTag = "1.2.4";
+    })
+  ];
+
+  loadDockerImages = writeShellScript "load-docker-images.sh" ''
+    for image in ${toString dockerImages}; do
+      [ -f "$image" ] || continue
+      docker load --input=$image
+    done
+  '';
+in
+nixosTest {
+  name = "egil-test-suite";
+
+  machine = {
+    environment.systemPackages = [
+      egil.test.suite
+    ];
+
+    virtualisation = {
+      docker.enable = true;
+      diskSize = 1024; # 512 is not enough
+    };
+  };
+
+  testScript = ''
+    machine.wait_for_unit("docker.service")
+    machine.execute("${loadDockerImages}")
+    machine.succeed("run_test_suite")
+  '';
+}

--- a/nix/egil/tools/all.nix
+++ b/nix/egil/tools/all.nix
@@ -1,0 +1,30 @@
+{ lib
+, egil
+, curl
+, symlinkJoin
+}:
+
+let
+  inherit (builtins) attrValues;
+  inherit (lib) filterAttrs unique isDerivation;
+  inherit (egil.internal) version meta;
+
+  pname = "egil-tools";
+  egilToolDrvs = attrValues (filterAttrs (n: v: n != "all" && isDerivation v) egil.tools);
+  license = unique (map (drv: drv.meta.license) egilToolDrvs);
+in
+symlinkJoin {
+  inherit pname version;
+  name = "${pname}-${version}";
+
+  paths = egilToolDrvs;
+
+  meta = meta // {
+    description = "Tools associated with the EGIL client";
+    longDescription = ''
+      Tools that may simplify usage of the EGIL client. All tools can be run
+      with the -h flag to show a brief description of how to run the tool.
+    '';
+    inherit license;
+  };
+}

--- a/nix/egil/tools/default.nix
+++ b/nix/egil/tools/default.nix
@@ -1,0 +1,47 @@
+{ lib
+, buildInputs
+, egil
+, filename
+, makeWrapper
+, meta
+, stdenvNoCC
+, wrapProgram ? false
+}:
+
+let
+  inherit (builtins) replaceStrings split elemAt;
+  inherit (lib) optional optionalString makeSearchPath;
+  inherit (egil.internal) version;
+
+  toolName = elemAt (split "\\." filename) 0;
+  mainProgram = filename;
+in
+stdenvNoCC.mkDerivation {
+  pname = "egil-tools-${toolName}";
+  inherit version;
+
+  src = ./../../../tools/${filename};
+
+  outputs = [ "bin" "out" ];
+  propagatedBuildOutputs = [ ];
+
+  strictDeps = true;
+
+  inherit buildInputs;
+  nativeBuildInputs = optional wrapProgram makeWrapper;
+
+  phases = [ "installPhase" "fixupPhase" ];
+
+  installPhase = ''
+    mkdir -p $bin/bin
+    cp $src $bin/bin/${mainProgram}
+
+    mkdir $out
+  '';
+
+  postFixup = optionalString wrapProgram ''
+    wrapProgram $bin/bin/${mainProgram} --prefix PATH : "${makeSearchPath "bin" buildInputs}"
+  '';
+
+  meta = meta // { inherit mainProgram; };
+}

--- a/nix/egil/tools/fetch_metadata.nix
+++ b/nix/egil/tools/fetch_metadata.nix
@@ -1,0 +1,30 @@
+{ lib
+, callPackage
+, egil
+, python3
+, pythonPackages
+}:
+
+let
+  inherit (egil.internal) meta;
+in
+callPackage ./default.nix {
+  filename = "fetch_metadata.py";
+
+  buildInputs = [
+    (python3.withPackages (pkgs: with pkgs; [
+      python-jose
+    ]))
+  ];
+
+  meta = meta // {
+    description = "Download and verify federated TLS authentication metadata";
+    longDescription =
+      "The script fetch_metadata.py will both download and verify the " +
+      "authentication metadata against a key. The decoded metadata can " +
+      "then be used by the EGIL client in order to connect to and " +
+      "authenticate a server.";
+
+    license = lib.licenses.mit;
+  };
+}

--- a/nix/egil/tools/list_metadata.nix
+++ b/nix/egil/tools/list_metadata.nix
@@ -1,0 +1,26 @@
+{ lib
+, callPackage
+, python3
+, egil
+, pythonPackages
+}:
+
+let
+  inherit (egil.internal) meta;
+in
+callPackage ./default.nix {
+  filename = "list_metadata.py";
+
+  buildInputs = [
+    (python3.withPackages (pkgs: with pkgs; [
+      url-normalize
+    ]))
+  ];
+
+  meta = meta // {
+    description = "List contents in authentication metadata";
+    longDescription = "A script for listing entities from the metadata.";
+
+    license = lib.licenses.mit;
+  };
+}

--- a/nix/egil/tools/public_key_pin.nix
+++ b/nix/egil/tools/public_key_pin.nix
@@ -1,0 +1,29 @@
+{ callPackage
+, bash
+, egil
+, openssl
+}:
+
+let
+  inherit (egil.internal) meta;
+in
+callPackage ./default.nix {
+  filename = "public_key_pin.sh";
+
+  buildInputs = [
+    bash.out
+    openssl.bin
+  ];
+
+  meta = meta // {
+    description =
+      "A script for generating a public key pin based on an x509 certificate";
+    longDescription =
+      "Extracts public key from a x509 certificate and outputs its pin. " +
+      "Depends on OpenSSL.";
+
+    license = null;
+  };
+
+  wrapProgram = true;
+}

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -1,0 +1,35 @@
+{
+  privateOverlay
+}:
+
+(final: prev:
+  let
+    pkgs = final.appendOverlays [
+      privateOverlay
+    ];
+
+    inherit (pkgs) callPackage;
+    inherit (pkgs.lib) recurseIntoAttrs;
+    inherit (pkgs.egil.internal) version meta;
+  in
+  {
+    egil = {
+      scim-client = callPackage ./egil/scim-client.nix { };
+
+      plugins = recurseIntoAttrs {
+        echo = callPackage ./egil/plugins/echo.nix { };
+      };
+
+      test = recurseIntoAttrs {
+        server = callPackage ./egil/test/server.nix { };
+        suite = callPackage ./egil/test/suite.nix { };
+      };
+
+      tools = recurseIntoAttrs {
+        all = callPackage ./egil/tools/all.nix { };
+        fetch_metadata = callPackage ./egil/tools/fetch_metadata.nix { };
+        list_metadata = callPackage ./egil/tools/list_metadata.nix { };
+        public_key_pin = callPackage ./egil/tools/public_key_pin.nix { };
+      };
+    };
+  })

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -1,0 +1,31 @@
+{ lib
+, egil
+, gdb
+, isSupportedOnCurrentSystem
+, mkShell
+, nix-utils
+, callPackage
+}:
+
+let
+  inherit (lib) optional;
+  inherit (nix-utils) createDebugSymbolsSearchPath;
+
+  debugInfoSearchPath =
+    callPackage createDebugSymbolsSearchPath { } [ egil.scim-client.debug ];
+in
+mkShell {
+  packages = [
+    gdb
+    egil.scim-client.debug.bin
+  ] ++ optional (isSupportedOnCurrentSystem egil.test.suite) egil.test.suite;
+
+  inputsFrom = [
+    egil.scim-client.debug
+  ];
+
+  shellHook = ''
+    export NIX_DEBUG_INFO_DIRS=${debugInfoSearchPath}
+    alias gdb='gdb --directory=${egil.scim-client.debug.src}/src'
+  '';
+}

--- a/test/test_server_go/README.md
+++ b/test/test_server_go/README.md
@@ -31,6 +31,12 @@ go build
 You should now have an executable binary named EGILTestServer in
 that directory.
 
+#### Building using Nix
+```
+cd <project-root>
+nix build '.#egil-test-server'
+```
+
 ### Generate server certificate and private key
 
 If you don't already have a certificate and private key which the test server
@@ -83,3 +89,13 @@ SchoolUnits.log).
 
 If there were existing log files when the server started, they will be
 truncated.
+
+## Running the test suite
+The test suite can be started by running the
+[run_test_suite](../scripts/run_test_suite) file from any directory.
+
+### Using Nix
+```shell
+cd <project-root>
+nix run '.#egil-test-suite`
+```


### PR DESCRIPTION
I believe the documentation introduced with [this commit](https://github.com/Sambruk/EgilSCIM/commit/fb918da03f6f21e64283d41ef99b97ca7ecf2bcd) should be helpful to understand  what is added.

To summarize, [Nix](https://nixos.org/) is a cross-platform package manager. It could build and test packages without an external dependency by managing everything itself. Flakes are a relatively new Nix feature that improves reproducibility, composability and usability in the Nix ecosystem[^1]. The things flake can be used include but not limited to build packages, run tests, create development environments or NixOS modules[^2]. The one added with this PR includes the first three (so, no NixOS module).

I don't want to repeat everything about Nix or Flakes. I think it would be better if I could answer your questions instead.

[^1]: https://www.tweag.io/blog/2020-05-25-flakes/
[^2]: https://nixos.wiki/wiki/Flakes#Output_schema