### PR TITLE
Removes a warning.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 #### Bugfixes
   - Better warning messages when a teacher's employment points to a
     non-existant school unit (#127)
+  - There is no longer a warning if a relation is defined by a
+    "remote" attribute that is potentially multi-valued (#131)
 
 ## v2.8.0 (2021-11-23)
 #### New features

--- a/src/model/object_list.hpp
+++ b/src/model/object_list.hpp
@@ -49,12 +49,6 @@ public:
     std::shared_ptr<base_object> get_object_for_attribute(const std::string &attribute, const std::string &id) {
         for (const auto &object : objects) {
             const string_vector &values = object.second->get_values(attribute);
-            if (!values.empty() && values.size() > 1) {
-                std::cerr << "Expected single value for "
-                          << object.second->getSS12000type()
-                          << " " << attribute << " " << id
-                          << " found: " << values.size() << std::endl;
-            }
             for (auto && value: values) {
                 if (value == id)
                     return object.second;


### PR DESCRIPTION
There should be valid use cases where a relation is defined with a "remote"
attribute which can be multi-valued.

For instance EPPN can be used as a key, but it should also be possible
for users to have multiple EPPNs (even if it's not supported in SS12000:2018,
it is supported in 2020, and we can imagine data sources where users have
multiple user names)

Fixes #131