### PR TITLE
fetch_metadata.py has more robust handling of a bad cached file.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 #### New features
   - Function for unprovisioning all data (#169)
 
+#### Bugfixes
+  - fetch_metadata.py has more robust handling of a bad cached file (#168)
+
 ## v2.12.0 (2022-12-08)
 #### New features
   - Functionality for transforming attributes from the data source (#165)

--- a/tools/fetch_metadata.py
+++ b/tools/fetch_metadata.py
@@ -60,13 +60,18 @@ def get_and_verify(url, keys, output: str) -> bool:
 
 def still_valid(cached: str) -> bool:
     """Checks if a metadata file is still valid according to its cache_ttl"""
-    with open(cached, 'r') as f:
-        cached_dict = json.load(f)
+    try:
+        with open(cached, 'r') as f:
+            cached_dict = json.load(f)
 
-    cache_ttl = cached_dict.get('cache_ttl', 3600)
-    mtime = os.path.getmtime(cached)
+        cache_ttl = cached_dict.get('cache_ttl', 3600)
+        mtime = os.path.getmtime(cached)
     
-    return time.time() < mtime + cache_ttl
+        return time.time() < mtime + cache_ttl
+    except Exception as e:
+        print("Failed to check if cached metadata was valid")
+        error_print(e)
+        return False
 
 if __name__ == '__main__':
 


### PR DESCRIPTION
For instance if the cached metadata file has gotten corrupt, empty or not possible to read, we will now download a new version rather than just print an error and exit.

Fixes #168