### PR TITLE
CSV separator can now be tab (by setting csv-separator = \t)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 ## Releases
 
 ## Unreleased
+#### Features
+  - The CSV separator character can now be a tab character (#193)
+  
 #### Bugfixes
-  - Temporary CA store file for FedTLS now works on Windows (191)
+  - Temporary CA store file for FedTLS now works on Windows (#191)
 
 ## v2.15.0 (2023-06-13)
 #### New features

--- a/doc/USAGE.md
+++ b/doc/USAGE.md
@@ -203,6 +203,13 @@ the following additions:
  * The quote character can be configured (with the `csv-quote` variable)
  * UTF-8 encoded text is allowed
 
+If you wish to use the tab character as a separator character it needs to be
+set with a special escape sequence:
+
+```
+csv-separator = \t
+```
+
 ## Loading objects from SQL
 
 If your source data is in a relational database, loading directly from SQL instead

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -27,7 +27,12 @@ char csv_separator() {
 
     auto separator_setting = config_file::instance().get("csv-separator", true);
     if (!separator_setting.empty()) {
-        separator = separator_setting[0];
+        if (separator_setting == "\\t") {
+            separator = '\t';
+        }
+        else {
+            separator = separator_setting[0];
+        }
     }
     return separator;
 }


### PR DESCRIPTION
Fixes #193