### PR TITLE
Removed move version of base_object::append_values.

### DIFF
--- a/src/model/base_object.hpp
+++ b/src/model/base_object.hpp
@@ -152,20 +152,6 @@ public:
 			attributes.emplace(std::make_pair(attr, values));
 	}
 
-	void append_values(const std::string &attr, string_vector &&values, bool unique = false) {
-		auto iter = attributes.find(attr);
-		if (iter != attributes.end()) {
-			if (unique) {
-				for (auto &&val: values) {
-					if (std::find(std::begin(iter->second), std::end(iter->second), val) == std::end(iter->second))
-						iter->second.emplace_back(std::move(val));
-				}
-			} else
-				iter->second.insert(iter->second.end(), values.begin(), values.end());
-		} else
-			attributes.emplace(std::make_pair(attr, std::move(values)));
-	}
-
 	void add_attribute(const std::string &attr, const string_vector &values) {
 		auto iter = attributes.find(attr);
 

--- a/src/transformer_impl.cpp
+++ b/src/transformer_impl.cpp
@@ -33,7 +33,7 @@ void multi_attribute_transformer::apply(base_object* obj) const {
 }
 
 void regex_transformer::apply(base_object* obj) const {
-    auto values = obj->get_values(from);
+    string_vector values = obj->get_values(from);
 
     for (const auto& value : values) {
         bool foundMatch = false;


### PR DESCRIPTION
The move version doesn't seem to improve performance and is suspected of causing heap corruption on Windows Server when built with MSVC.