### PR TITLE
In the Windows version a heap corruption problem was fixed in the LDAP code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Releases
 
+## Unreleased
+#### Bugfixes
+  - In the Windows version a heap corruption problem was fixed in the LDAP code (#211)
+
 ## v2.17.0 (2024-02-27)
 #### Features
   - Built-in support for converting national test activity names to UUIDs (#206)

--- a/src/ldap_wrapper.cpp
+++ b/src/ldap_wrapper.cpp
@@ -96,7 +96,7 @@ int ldap_search_ext_s_utf8(
         int n = MultiByteToWideChar(CP_UTF8, MB_PRECOMPOSED, attrs[i], (int)strlen(attrs[i]), wattrs[i], buffer_size);
         wattrs[i][n] = 0;
     }
-    wattrs[num_attrs] = nullptr;
+    wattrs.push_back(nullptr);
 
     return ldap_search_ext_sW(ld, base_buffer, scope,
         filter_buffer,


### PR DESCRIPTION
Fixes #211