### PR TITLE
When using the --rebuild-cache feature, a failure to GET objects will now terminate the client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
   - Contents of the cache file can now be printed in JSON format (#54)
   - New functionality for blacklisting users (#223)
   - Space for the cache file is now pre-allocated before SCIM operations start (#197)
+  
+#### Bugfixes
+  - When using the --rebuild-cache feature, a failure to GET objects will now terminate the client (#205)
 
 ## v2.18 (2024-11-19)
 #### Features

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -442,6 +442,7 @@ int main(int argc, char *argv[]) {
                 all_scim_objects = scim_actions.get_all_objects_from_scim_server();
             } catch (const std::runtime_error& e) {
                 std::cerr << "Failed to get objects from SCIM server (" << e.what() << ")" << std::endl;
+                return EXIT_FAILURE;
             }
         }
 


### PR DESCRIPTION
Fixes #205