### PR TITLE
Swaps dynamic/static linking for curl and boost on Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Releases
 
+## Unreleased
+#### Misc
+  - On Linux, dynamic linking now used for OpenSSL, static linking for Boost (#261)
+
 ## v2.23 (2026-04-24)
 #### Features
   - External processes can now be used as a data source (#251)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -15,8 +15,10 @@
       "generator": "Unix Makefiles",
       "binaryDir": "${sourceDir}/build",
       "cacheVariables": {
-          "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
-	  "CMAKE_BUILD_TYPE": "RelWithDebInfo"
+        "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo",
+        "VCPKG_TARGET_TRIPLET": "x64-linux-dynamic-static-boost",
+        "VCPKG_OVERLAY_TRIPLETS": "${sourceDir}/vcpkg-triplets"
       }
     },
     {
@@ -24,9 +26,11 @@
       "generator": "Unix Makefiles",
       "binaryDir": "${sourceDir}/build",
       "cacheVariables": {
-          "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
-	  "CMAKE_BUILD_TYPE": "Debug"
+        "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
+        "CMAKE_BUILD_TYPE": "Debug",
+        "VCPKG_TARGET_TRIPLET": "x64-linux-dynamic-static-boost",
+        "VCPKG_OVERLAY_TRIPLETS": "${sourceDir}/vcpkg-triplets"
       }
-    }            
+    }
   ]
 }

--- a/vcpkg-triplets/x64-linux-dynamic-static-boost.cmake
+++ b/vcpkg-triplets/x64-linux-dynamic-static-boost.cmake
@@ -1,0 +1,16 @@
+# This triplet uses dynamic linking by default on Linux, but static linking for Boost.
+#
+# One reason to use dynamic linking is to avoid problems that mixing OpenSSL versions
+# can lead to (if our statically linked OpenSSL has a different version than what is
+# dynamically loaded, for instance by an ODBC driver).
+# A reason to use static linking for Boost is that the version included in Debian keeps
+# changing.
+set(VCPKG_TARGET_ARCHITECTURE x64)
+set(VCPKG_CMAKE_SYSTEM_NAME Linux)
+
+set(VCPKG_CRT_LINKAGE dynamic)
+set(VCPKG_LIBRARY_LINKAGE dynamic)
+
+if(PORT MATCHES "^boost-")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif()


### PR DESCRIPTION
- [x] CHANGELOG.md updated
- [x] Docs updated/added for any new functionality, behavior changes, or UI changes (per docs/STYLE_GUIDE.md)
- [x] Unit tests run without errors
- [x] Test suite runs without errors
